### PR TITLE
fix(PlayCommand): Reduce YT Api Usage When Requesting Spotify Playlists

### DIFF
--- a/src/commands/PlayCommand.ts
+++ b/src/commands/PlayCommand.ts
@@ -4,6 +4,7 @@ import { ServerQueue } from "../structures/ServerQueue";
 import { Util, MessageEmbed, VoiceChannel } from "discord.js";
 // @ts-expect-error-next-line
 import { getData } from "spotify-url-info";
+import ytsr, { Video as SRVideo } from "ytsr";
 import { decodeHTML } from "entities";
 import { IMessage, ISong, IGuild, ITextChannel } from "../../typings";
 import { DefineCommand } from "../utils/decorators/DefineCommand";
@@ -82,8 +83,8 @@ export class PlayCommand extends BaseCommand {
             if (input[1] === "track") {
                 const trackData = await getData(url);
                 const trackSearchString = `${trackData.artists[0].name} - ${trackData.name}`;
-                const videoResult = await this.client.youtube.searchVideos(trackSearchString, 1);
-                const queuedVideo = await this.client.youtube.getVideo(videoResult[0].id);
+                const videoResult = await ytsr(trackSearchString, { limit: 1, safeSearch: false });
+                const queuedVideo = await this.client.youtube.getVideo((videoResult.items[0] as SRVideo).id);
                 return this.handleVideo(queuedVideo, message, voiceChannel);
             } else if (input[1] === "playlist") {
                 try {
@@ -95,8 +96,8 @@ export class PlayCommand extends BaseCommand {
                             .setThumbnail(playlistData.images[0].url)
                     );
                     for (const title of playlistSearchStrings) {
-                        const videoResults = await this.client.youtube.searchVideos(title, 1);
-                        const queuedVideo = await this.client.youtube.getVideo(videoResults[0].id);
+                        const videoResults = await ytsr(title, { limit: 1, safeSearch: false });
+                        const queuedVideo = await this.client.youtube.getVideo((videoResults.items[0] as SRVideo).id);
                         await this.handleVideo(queuedVideo, message, voiceChannel, true);
                     }
                     message.channel.messages.fetch(addingPlaylistVideoMessage.id, false).then(m => m.delete()).catch(e => this.client.logger.error("SP_PLAYLIST_ERR:", e));


### PR DESCRIPTION
change the method of searching tracks to only use scraping to reduce YT API usage