### PR TITLE
 fix(*): Fix file url parsing for linux paths 

### DIFF
--- a/src/utils/functions/importURLToString.ts
+++ b/src/utils/functions/importURLToString.ts
@@ -1,5 +1,5 @@
 import { URL } from "url";
-import { resolve, isAbsolute, normalize, relative } from "path";
+import { isAbsolute } from "path";
 import { platform } from "os";
 
 export function importURLToString(url: string): string {
@@ -9,8 +9,7 @@ export function importURLToString(url: string): string {
 
     if (!isAbsolute(paths.join("/"))) {
         const hostPlatform = platform();
-        if (hostPlatform === "linux")
-            return decodeURIComponent(`/${paths.join("/")}`);
+        if (hostPlatform === "linux") return decodeURIComponent(`/${paths.join("/")}`);
     }
     return decodeURIComponent(paths.join("/"));
 }

--- a/src/utils/functions/importURLToString.ts
+++ b/src/utils/functions/importURLToString.ts
@@ -1,15 +1,12 @@
 import { URL } from "url";
-import { isAbsolute } from "path";
 import { platform } from "os";
 
 export function importURLToString(url: string): string {
-    const paths = new URL(url).pathname.split(/\/|\\/g).filter(Boolean);
+    const pathArray = new URL(url).pathname.split(/\/|\\/g).filter(Boolean);
 
-    paths.pop();
+    pathArray.pop();
 
-    if (!isAbsolute(paths.join("/"))) {
-        const hostPlatform = platform();
-        if (hostPlatform === "linux") return decodeURIComponent(`/${paths.join("/")}`);
-    }
-    return decodeURIComponent(paths.join("/"));
+    const path = pathArray.join("/");
+
+    return decodeURIComponent(`${platform() === "win32" ? "" : "/"}${path}`);
 }

--- a/src/utils/functions/importURLToString.ts
+++ b/src/utils/functions/importURLToString.ts
@@ -1,8 +1,16 @@
 import { URL } from "url";
+import { resolve, isAbsolute, normalize, relative } from "path";
+import { platform } from "os";
 
 export function importURLToString(url: string): string {
     const paths = new URL(url).pathname.split(/\/|\\/g).filter(Boolean);
 
     paths.pop();
+
+    if (!isAbsolute(paths.join("/"))) {
+        const hostPlatform = platform();
+        if (hostPlatform === "linux")
+            return decodeURIComponent(`/${paths.join("/")}`);
+    }
     return decodeURIComponent(paths.join("/"));
 }


### PR DESCRIPTION
Fix an issue where the `importURLToString()` function was resulting in a bad path. resolved by making sure it's returning an absolute path.