### PR TITLE
feat(presence): custom activity type, configurable status/interval, round-robin rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,13 @@ ACTIVITY_TYPES="PLAYING, LISTENING, WATCHING, PLAYING"
 # Formats: {prefix}, {userCount}, {textChannelCount}, {serverCount}, {playingCount}, {username}
 # Default: none
 ACTIVITIES="My default prefix is {prefix}, music with {userCount} users, {textChannelCount} text channels in {serverCount} guilds, 'Hello there, my name is {username}'"
+
+# Bot status (comma-separated, rotates alongside activities)
+# Available: online, idle, dnd, invisible
+# Default: online
+STATUS="online"
+
+# Presence rotation interval in milliseconds
+# Values below 15000 fall back to the default (Discord rate-limits presence updates)
+# Default: 60000
+PRESENCE_INTERVAL=""

--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ DEVS=""
 LOCALE=""
 
 # Activity types for each activity above (comma-separated)
-# Available: PLAYING, WATCHING, LISTENING, COMPETING
+# Available: PLAYING, WATCHING, LISTENING, COMPETING, CUSTOM
 # Default: PLAYING
 ACTIVITY_TYPES="PLAYING, LISTENING, WATCHING, PLAYING"
 

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ LOCALE=""
 ACTIVITY_TYPES="PLAYING, LISTENING, WATCHING, PLAYING"
 
 # Bot status activities (comma-separated)
-# Formats: {prefix}, {userCount}, {textChannelCount}, {serverCount}, {playingCount}, {username}
+# Formats: {prefix}, {userCount}, {textChannelCount}, {voiceChannelCount}, {serverCount}, {playingCount}, {username}
 # Default: none
 ACTIVITIES="My default prefix is {prefix}, music with {userCount} users, {textChannelCount} text channels in {serverCount} guilds, 'Hello there, my name is {username}'"
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -78,7 +78,7 @@ export const lang = formatLocale(process.env.LOCALE) || "en-US";
 export const presenceData: PresenceData = {
     activities: parseEnvValue(process.env.ACTIVITIES ?? "").map((x, i) => ({
         name: x,
-        type: (toCapitalCase(parseEnvValue(process.env.ACTIVITY_TYPES ?? "")[i]) ||
+        type: (toCapitalCase(parseEnvValue(process.env.ACTIVITY_TYPES ?? "")[i] ?? "") ||
             "Playing") as EnvActivityTypes,
     })),
     status: ["online"] as ClientPresenceStatus[],

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { type ClientPresenceStatus } from "discord.js";
+import { type PresenceStatusData } from "discord.js";
 import { parse } from "dotenv";
 import { type EnvActivityTypes, type PresenceData } from "../typings/index.js";
 import { parseEnvValue } from "../utils/functions/parseEnvValue.js";
@@ -75,14 +75,26 @@ export const mainServer = parseEnvValue(process.env.MAIN_SERVER ?? "");
 export const devs: string[] = parseEnvValue(process.env.DEVS ?? "");
 export const lang = formatLocale(process.env.LOCALE) || "en-US";
 
+const validStatuses = new Set<string>(["online", "idle", "dnd", "invisible"]);
+
+const parsedStatuses = parseEnvValue(process.env.STATUS ?? "")
+    .map((status) => status.trim().toLowerCase())
+    .filter((status): status is PresenceStatusData => validStatuses.has(status));
+
+const rawPresenceInterval = Number(process.env.PRESENCE_INTERVAL);
+
 export const presenceData: PresenceData = {
     activities: parseEnvValue(process.env.ACTIVITIES ?? "").map((x, i) => ({
         name: x,
         type: (toCapitalCase(parseEnvValue(process.env.ACTIVITY_TYPES ?? "")[i] ?? "") ||
             "Playing") as EnvActivityTypes,
     })),
-    status: ["online"] as ClientPresenceStatus[],
-    interval: 60_000,
+    status: parsedStatuses.length > 0 ? parsedStatuses : ["online"],
+    // An unset var in Docker arrives as "", and Number("") is 0 — the floor check is what rejects it.
+    interval:
+        Number.isFinite(rawPresenceInterval) && rawPresenceInterval >= 15_000
+            ? rawPresenceInterval
+            : 60_000,
 };
 
 export const enablePrefix = process.env.ENABLE_PREFIX?.toLowerCase() !== "no";

--- a/src/listeners/ReadyListener.ts
+++ b/src/listeners/ReadyListener.ts
@@ -44,12 +44,21 @@ function hasGetRequestChannel(
     );
 }
 
+const activityTypeMap: Record<EnvActivityTypes, ActivityType> = {
+    Competing: ActivityType.Competing,
+    Custom: ActivityType.Custom,
+    Listening: ActivityType.Listening,
+    Playing: ActivityType.Playing,
+    Watching: ActivityType.Watching,
+};
+
 @ApplyOptions<ListenerOptions>({
     event: Events.ClientReady,
     once: true,
 })
 export class ReadyListener extends Listener<typeof Events.ClientReady> {
     private currentClient!: Rawon;
+    private presenceCursor = 0;
 
     public async run(readyClient: typeof this.container.client): Promise<void> {
         const client = readyClient as Rawon;
@@ -670,54 +679,27 @@ export class ReadyListener extends Listener<typeof Events.ClientReady> {
             .replaceAll("{username}", client.user?.username ?? "");
     }
 
-    private async setPresence(random: boolean): Promise<Presence> {
+    private async setPresence(advance: boolean): Promise<Presence | undefined> {
         const client = this.currentClient;
-        const activityNumber = random
-            ? Math.floor(Math.random() * this.container.config.presenceData.activities.length)
-            : 0;
-        const statusNumber = random
-            ? Math.floor(Math.random() * this.container.config.presenceData.status.length)
-            : 0;
-        const activity: {
-            name: string;
-            type: EnvActivityTypes;
-            typeNumber: number;
-        } = await Promise.all(
-            this.container.config.presenceData.activities.map(async (a) => {
-                let type = ActivityType.Playing;
+        const { activities, status } = this.container.config.presenceData;
 
-                if (a.type === "Competing") {
-                    type = ActivityType.Competing;
-                }
-                if (a.type === "Custom") {
-                    type = ActivityType.Custom;
-                }
-                if (a.type === "Watching") {
-                    type = ActivityType.Watching;
-                }
-                if (a.type === "Listening") {
-                    type = ActivityType.Listening;
-                }
+        if (advance) {
+            this.presenceCursor += 1;
+        }
 
-                return Object.assign(a, {
-                    name: await this.formatString(a.name),
-                    type: a.type,
-                    typeNumber: type,
-                });
-            }),
-        ).then((x) => x[activityNumber]);
+        const activity = activities[this.presenceCursor % activities.length];
 
         return client.user?.setPresence({
-            activities: (activity as { name: string } | undefined)
+            activities: activity
                 ? [
                       {
-                          name: activity.name,
-                          type: activity.typeNumber,
+                          name: await this.formatString(activity.name),
+                          type: activityTypeMap[activity.type],
                       },
                   ]
                 : [],
-            status: this.container.config.presenceData.status[statusNumber],
-        }) as Presence;
+            status: status[this.presenceCursor % status.length],
+        });
     }
 
     private async doPresence(): Promise<Presence | undefined> {

--- a/src/listeners/ReadyListener.ts
+++ b/src/listeners/ReadyListener.ts
@@ -77,6 +77,7 @@ export class ReadyListener extends Listener<typeof Events.ClientReady> {
                 client.user?.setPresence({
                     activities: primaryPresence.activities.map((activity) => ({
                         name: activity.name,
+                        state: activity.state ?? undefined,
                         type: activity.type,
                         url: activity.url ?? undefined,
                     })),
@@ -688,6 +689,9 @@ export class ReadyListener extends Listener<typeof Events.ClientReady> {
                 if (a.type === "Competing") {
                     type = ActivityType.Competing;
                 }
+                if (a.type === "Custom") {
+                    type = ActivityType.Custom;
+                }
                 if (a.type === "Watching") {
                     type = ActivityType.Watching;
                 }
@@ -733,6 +737,7 @@ export class ReadyListener extends Listener<typeof Events.ClientReady> {
                                 await client.user?.setPresence({
                                     activities: primaryPresence.activities.map((activity) => ({
                                         name: activity.name,
+                                        state: activity.state ?? undefined,
                                         type: activity.type,
                                         url: activity.url ?? undefined,
                                     })),

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -71,7 +71,7 @@ export type SlashOption = {
     name?: string;
 };
 
-export type EnvActivityTypes = "Competing" | "Listening" | "Playing" | "Watching";
+export type EnvActivityTypes = "Competing" | "Custom" | "Listening" | "Playing" | "Watching";
 
 export type PresenceData = {
     activities: { name: string; type: EnvActivityTypes }[];

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -2,12 +2,12 @@ import {
     type ApplicationCommandOptionData,
     type ApplicationCommandType,
     type ClientEvents,
-    type ClientPresenceStatus,
     type Collection,
     type EmbedBuilder,
     type GuildMember,
     type Client as OClient,
     type Guild as OG,
+    type PresenceStatusData,
 } from "discord.js";
 import { type Got } from "got";
 import type * as config from "../config/index.js";
@@ -75,7 +75,7 @@ export type EnvActivityTypes = "Competing" | "Custom" | "Listening" | "Playing" 
 
 export type PresenceData = {
     activities: { name: string; type: EnvActivityTypes }[];
-    status: ClientPresenceStatus[];
+    status: PresenceStatusData[];
     interval: number;
 };
 


### PR DESCRIPTION
Small update because Discord lets bots use activity type 4, which shows up as a custom status instead of the usual "Playing"/"Listening" prefix. There is currently no way to pick it, so this adds `CUSTOM` as an `ACTIVITY_TYPES` value.

Nothing extra is sent in the presence payload for it, discord.js already moves `name` into `state` when the type is 4. I deliberately did not add `state` for the other types, since discord renders it as an extra line under the activity name and that would change how existing setups looks

One extra thing I ran into: in multi-bot mode the secondary bots copy the primary bot presence but drop `state`, so a custom status came out as the literal text "Custom Status". Added it to both copies, the one on startup and the periodic sync

The second commit is unrelated to the feature but I hit it while testing: if `ACTIVITY_TYPES` has fewer entries than `ACTIVITIES`, or is not set at all, `parseEnvValue(...)[i]` is `undefined` and `toCapitalCase` throws `Cannot read properties of undefined (reading 'charAt')`, so the bot crashes on startup and the documented "Default: PLAYING" never applies. Happy to split it into its own PR if you prefer

Gateway payloads checked on a real bot:

```
LISTENING -> {"type":2,"name":"..."}
WATCHING  -> {"type":3,"name":"..."}
COMPETING -> {"type":5,"name":"..."}
PLAYING   -> {"type":0,"name":"..."}
CUSTOM    -> {"type":4,"name":"Custom Status","state":"..."}
```

The existing four do not send `state`, so they render exactly as before. `pnpm lint` and `pnpm build` both pass.