### PR TITLE
chore: align node engine requirement and drop unused tweetnacl

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## Installation
 
 ### Prerequisites
-- [Node.js](https://nodejs.org) version `20.0.0` or higher
+- [Node.js](https://nodejs.org) version `22.12.0` or higher
 - [FFmpeg](https://ffmpeg.org/) for audio processing
 
 > **Note**: Docker users don't need to install FFmpeg manually — it's included in the Docker image.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "dev": "pnpm build && pnpm start"
     },
     "engines": {
-        "node": ">=20.0.0",
+        "node": ">=22.12.0",
         "npm": ">=7.0.0"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
         "puppeteer": "^25.3.0",
         "puppeteer-core": "^25.3.0",
         "tslib": "2.8.1",
-        "tweetnacl": "1.0.3",
         "zip-lib": "^1.4.0"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      tweetnacl:
-        specifier: 1.0.3
-        version: 1.0.3
       zip-lib:
         specifier: ^1.4.0
         version: 1.4.0
@@ -1586,9 +1583,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tweetnacl@1.0.3:
-    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
-
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -3058,8 +3052,6 @@ snapshots:
   ts-mixer@6.0.4: {}
 
   tslib@2.8.1: {}
-
-  tweetnacl@1.0.3: {}
 
   type-fest@4.41.0: {}
 


### PR DESCRIPTION
While looking at the presence code for #1677 i noticed two unrelated things, so here they are as their own PR:

bumped engines.node to >=22.12.0 — discord.js voice 0.19.2 requires it and package.json still said >=20.0.0. left npm alone and stopped at >=22.12.0 rather than >=24 so working Node 22 installs don't get excluded. README updated to match

dropped the unused tweetnacl dep and regenerated the lockfile. nothing under src/ references it and discord.js voice no longer lists it as supported. kept opusscript since it's still a live peer of prism-media

verified with a docker build — image builds and generateDependencyReport() shows aes-256-gcm: yes, opusscript: 0.0.8, libopus: yes