### PR TITLE
fix: handle rejected message deletions and bare youtu.be links

### DIFF
--- a/src/listeners/InteractionCreateListener.ts
+++ b/src/listeners/InteractionCreateListener.ts
@@ -245,7 +245,7 @@ export class InteractionCreateListener extends Listener<typeof Events.Interactio
                         .fetch(interaction.message.id)
                         .catch(() => null);
                     if (msg?.deletable === true) {
-                        void msg.delete();
+                        void msg.delete().catch(() => null);
                     }
                 }
             }

--- a/src/listeners/VoiceStateUpdateListener.ts
+++ b/src/listeners/VoiceStateUpdateListener.ts
@@ -642,36 +642,43 @@ export class VoiceStateUpdateListener extends Listener<typeof Events.VoiceStateU
         (guild.queue as ServerQueue).timeout = setTimeout(async () => {
             await queue.destroy();
             void (async () => {
-                const msg = await queue.textChannel.send({
-                    flags: MessageFlags.SuppressNotifications,
-                    embeds: [
-                        createEmbed(
-                            "info",
-                            `⏹️ **|** ${__mf("events.voiceStateUpdate.deleteQueue", {
-                                duration: `**\`${duration}\`**`,
-                            })}`,
-                        ).setAuthor({ name: __("events.voiceStateUpdate.deleteQueueFooter") }),
-                    ],
-                });
-                if (isRequestChannel) {
+                const msg = await queue.textChannel
+                    .send({
+                        flags: MessageFlags.SuppressNotifications,
+                        embeds: [
+                            createEmbed(
+                                "info",
+                                `⏹️ **|** ${__mf("events.voiceStateUpdate.deleteQueue", {
+                                    duration: `**\`${duration}\`**`,
+                                })}`,
+                            ).setAuthor({ name: __("events.voiceStateUpdate.deleteQueueFooter") }),
+                        ],
+                    })
+                    .catch(() => null);
+                if (isRequestChannel && msg) {
                     setTimeout(() => {
                         void msg.delete().catch(() => null);
                     }, 60_000);
                 }
             })();
         }, timeout);
-        (async () => {
-            const msg = await queue.textChannel.send({
-                flags: MessageFlags.SuppressNotifications,
-                embeds: [
-                    createEmbed(
-                        "warn",
-                        `⏸️ **|** ${__mf("events.voiceStateUpdate.pauseQueue", {
-                            duration: `**\`${duration}\`**`,
-                        })}`,
-                    ).setAuthor({ name: __("events.voiceStateUpdate.pauseQueueFooter") }),
-                ],
-            });
+        void (async () => {
+            const msg = await queue.textChannel
+                .send({
+                    flags: MessageFlags.SuppressNotifications,
+                    embeds: [
+                        createEmbed(
+                            "warn",
+                            `⏸️ **|** ${__mf("events.voiceStateUpdate.pauseQueue", {
+                                duration: `**\`${duration}\`**`,
+                            })}`,
+                        ).setAuthor({ name: __("events.voiceStateUpdate.pauseQueueFooter") }),
+                    ],
+                })
+                .catch(() => null);
+            if (!msg) {
+                return;
+            }
             queue.lastVSUpdateMsg = msg.id;
             if (isRequestChannel) {
                 setTimeout(() => {

--- a/src/structures/ServerQueue.ts
+++ b/src/structures/ServerQueue.ts
@@ -902,8 +902,8 @@ export class ServerQueue {
             (async () => {
                 await this.textChannel.messages
                     .fetch(this._lastMusicMsg ?? "")
-                    .then((msg) => {
-                        void msg.delete();
+                    .then(async (msg) => {
+                        await msg.delete();
                         return 0;
                     })
                     .catch((error: unknown) => {
@@ -929,8 +929,8 @@ export class ServerQueue {
             (async () => {
                 await this.textChannel.messages
                     .fetch(this._lastVSUpdateMsg ?? "")
-                    .then((msg) => {
-                        void msg.delete();
+                    .then(async (msg) => {
+                        await msg.delete();
                         return 0;
                     })
                     .catch((error: unknown) => {

--- a/src/utils/handlers/general/checkQuery.ts
+++ b/src/utils/handlers/general/checkQuery.ts
@@ -44,7 +44,7 @@ export function checkQuery(string: string): QueryData {
                 (url.pathname.startsWith("/watch") ||
                     url.pathname.startsWith("/shorts/") ||
                     url.pathname.startsWith("/live/"))) ||
-            (isYouTuBe && url.pathname !== "")
+            (isYouTuBe && url.pathname.length > 1)
         ) {
             result.type = "track";
         } else {

--- a/src/utils/handlers/general/checkQuery.ts
+++ b/src/utils/handlers/general/checkQuery.ts
@@ -44,7 +44,7 @@ export function checkQuery(string: string): QueryData {
                 (url.pathname.startsWith("/watch") ||
                     url.pathname.startsWith("/shorts/") ||
                     url.pathname.startsWith("/live/"))) ||
-            (isYouTuBe && url.pathname.length > 1)
+            (isYouTuBe && url.pathname.split("/").filter(Boolean).length > 0)
         ) {
             result.type = "track";
         } else {

--- a/src/utils/handlers/general/play.ts
+++ b/src/utils/handlers/general/play.ts
@@ -102,15 +102,22 @@ export async function play(
             if (!guild.queue?.songs.first()) {
                 await queue.destroy();
                 if (!isRequestChannel) {
-                    const msg = await queue.textChannel.send({
-                        flags: MessageFlags.SuppressNotifications,
-                        embeds: [
-                            createEmbed("info", `👋 **|** ${__("utils.generalHandler.leftVC")}`),
-                        ],
-                    });
-                    setTimeout(() => {
-                        void msg.delete();
-                    }, 3_500);
+                    const msg = await queue.textChannel
+                        .send({
+                            flags: MessageFlags.SuppressNotifications,
+                            embeds: [
+                                createEmbed(
+                                    "info",
+                                    `👋 **|** ${__("utils.generalHandler.leftVC")}`,
+                                ),
+                            ],
+                        })
+                        .catch(() => null);
+                    if (msg) {
+                        setTimeout(() => {
+                            void msg.delete().catch(() => null);
+                        }, 3_500);
+                    }
                 }
             }
         }, 60_000);


### PR DESCRIPTION
## Summary

Three small fixes found while reading through the message cleanup paths and query detection.

> Description corrected after review. The original text overstated the `youtu.be` change as an API skip and gave a wrong rationale for one of the `void` fixes. Both are corrected below, and a follow-up commit handles `https://youtu.be//`. Thanks to CocoLng for catching all three.

### Unhandled rejections on message cleanup

`msg.delete()` and `textChannel.send()` were called without a rejection handler in a few places. Deleting a message a moderator already removed throws `Unknown Message` (10008), and sending throws whenever the bot loses **Send Messages** in a text channel. Both are expected in normal operation and are already ignored elsewhere with `.catch(() => null)`, but at these call sites they escaped to `process.on("unhandledRejection")` and spammed the logs.

Sites fixed:
- `play.ts` idle-disconnect notice
- `VoiceStateUpdateListener` pause and delete-queue notices
- `InteractionCreateListener` unauthorized button cleanup
- `ServerQueue` `lastMusicMsg` / `lastVSUpdateMsg` setters, where the delete now chains into the existing `.catch` that already treats 10008 as benign

On the `VoiceStateUpdateListener` pause notice: it ran in an async IIFE that was never `void`ed, so a failed send escaped as an unhandled rejection. My original claim that this left `lastVSUpdateMsg` pointing at a stale message id was wrong. Line 641 sets it to `null` before the IIFE runs, and the setter assigns unconditionally, so the field is already `null` regardless of whether the send succeeds. The `void` and the early return are still correct, just for the rejection-handling reason alone.

### Bare `youtu.be` links detected as tracks

`checkQuery` classified any `youtu.be` URL as a track via `url.pathname !== ""`, but the WHATWG URL parser normalises a bare host to `"/"`, so that test never excluded anything:

```js
new URL("https://youtu.be").pathname   // "/"
new URL("https://youtu.be/").pathname  // "/"
```

`https://youtu.be/` was therefore reported as `type: "track"`. Splitting the path and dropping empty segments, the same idiom the Spotify branch above already uses, means only links carrying an actual id count, and it also covers `https://youtu.be//`.

**Scope of this change:** it corrects the reported `type` only. It does **not** avoid the wasted request. `searchTrack()` branches on `isURL`, not `type`, and `isURL` is unchanged for every input, so a bare `youtu.be` link still reaches `resolveMusic()` and still costs the ~10s round trip before yt-dlp fails. `type` is read in exactly two places (`PlayCommand.ts:143`, `MessageCreateListener.ts:451`), both only testing for `playlist`/`artist`, so `track` to `unknown` is inert today. `searchTrack()` would be the place to actually skip the call, but that belongs in its own PR and needs to stay narrow: unknown-source URLs legitimately reach working yt-dlp extractors, so a blanket `type !== "unknown"` guard would break Vimeo, Twitch and others.

Behaviour after the change:

| Input | Before | After |
| --- | --- | --- |
| `https://youtu.be/` | `track` | `unknown` |
| `https://youtu.be` | `track` | `unknown` |
| `https://youtu.be//` | `track` | `unknown` |
| `https://youtu.be/dQw4w9WgXcQ` | `track` | `track` |
| `https://youtu.be//dQw4w9WgXcQ` | `track` | `track` |
| `https://youtu.be/abc?list=PL1` | `playlist` | `playlist` |
| `https://youtube.com/watch?v=abc` | `track` | `track` |

Spotify, SoundCloud, YouTube Music, unknown-source URLs and non-URL queries are unaffected, and `isURL` is identical on every input.

## Testing

- `pnpm exec tsc --build tsconfig.json` passes
- `pnpm exec biome check .` passes, 110 files clean
- `checkQuery` compiled with swc and exercised against the table above plus shorts, live, playlist, artist, Spotify, SoundCloud, Vimeo, Twitch and non-URL inputs, asserting `isURL` matches `new URL()` on every case